### PR TITLE
Fix Cocoapods warning "[!] Smart quotes were detected and ignored in …

### DIFF
--- a/RealmTasks Apple/Podfile
+++ b/RealmTasks Apple/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 abstract_target 'RealmTasks' do
     use_frameworks!
 
-    pod 'RealmSwift'		#, '= 2.10.1’
+    pod 'RealmSwift'		#, '= 2.10.1'
     pod 'Cartography'       #, :git => 'https://github.com/robb/Cartography.git'
     pod 'SwiftLint', '= 0.16.1'
 


### PR DESCRIPTION
…your Podfile."

In terminal, "pod install" prints warning.
"To avoid issues in the future, you should not use TextEdit for editing it. If you are not using TextEdit, you should turn off smart quotes in your editor of choice."
Apparently accidentally introduced in commits 5a743a2 and 6b6c0fe.