### PR TITLE
Pod update Realm 3.0.2 and Cartography 2.1.0

### DIFF
--- a/RealmTasks Apple/Podfile
+++ b/RealmTasks Apple/Podfile
@@ -3,7 +3,7 @@ use_frameworks!
 
 abstract_target 'RealmTasks' do
     pod 'RealmSwift', '~> 3'
-    pod 'Cartography', '~> 2.0.0'
+    pod 'Cartography', '~> 2.1.0'
     pod 'SwiftLint', '= 0.23.1'
 
     target 'RealmTasks iOS' do
@@ -37,4 +37,3 @@ post_install do |installer|
         end
     end
 end
-

--- a/RealmTasks Apple/Podfile.lock
+++ b/RealmTasks Apple/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - Cartography (2.0.0)
-  - Realm (3.0.0):
-    - Realm/Headers (= 3.0.0)
-  - Realm/Headers (3.0.0)
+  - Cartography (2.1.0)
+  - Realm (3.0.2):
+    - Realm/Headers (= 3.0.2)
+  - Realm/Headers (3.0.2)
   - RealmLoginKit (0.1.3):
     - Realm
     - RealmLoginKit/Core (= 0.1.3)
@@ -10,13 +10,13 @@ PODS:
   - RealmLoginKit/Core (0.1.3):
     - Realm
     - TORoundedTableView
-  - RealmSwift (3.0.0):
-    - Realm (= 3.0.0)
+  - RealmSwift (3.0.2):
+    - Realm (= 3.0.2)
   - SwiftLint (0.23.1)
   - TORoundedTableView (0.1.3)
 
 DEPENDENCIES:
-  - Cartography (~> 2.0.0)
+  - Cartography (~> 2.1.0)
   - RealmLoginKit (from `https://raw.githubusercontent.com/realm-demos/realm-loginkit/master/RealmLoginKit%20Apple/RealmLoginKit.podspec`)
   - RealmSwift (~> 3)
   - SwiftLint (= 0.23.1)
@@ -27,13 +27,13 @@ EXTERNAL SOURCES:
     :podspec: https://raw.githubusercontent.com/realm-demos/realm-loginkit/master/RealmLoginKit%20Apple/RealmLoginKit.podspec
 
 SPEC CHECKSUMS:
-  Cartography: d295eb25ab54bb57eecd8c2f04e9648c850f1281
-  Realm: dec0de73be8c57506e39db72694d513c189493b3
+  Cartography: 19c2223a8dfed35d82b098d365213b7ceb25ab2b
+  Realm: 6f23fd1f178a09342eac21bfa7c2bf4312a7a180
   RealmLoginKit: 41a2fc61f3fa294e35c786b751133b1744f4d640
-  RealmSwift: 44a7090b16d1b22a406c6bf129bdd602db1bbecc
+  RealmSwift: 695393add1b8f9d5fa75dd16e6355cf3935f71e2
   SwiftLint: 1b670ce79284c76520f84060e87d645078fd32fa
   TORoundedTableView: cd1437ef81ab3888dea8c06d2dfe4795bcaac768
 
-PODFILE CHECKSUM: 42ed83ec676d9c0a11a35f236ac8a4f8c7733991
+PODFILE CHECKSUM: 4be34545f720c5d81c1c74e5f7de2b93c0cc0401
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
Update Realm tp 3.0.2, Cartography to 2.1.0

SafeArea suppport requires Cartography 2.1.0.

@dhmspector @austinzheng @icanzilb 